### PR TITLE
Fixed 'apt install make' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ LABEL description="Circadian analysis"
 USER root
 
 RUN apt-get update && \
-    apt-get upgrade -y --no-install-recommends \
-    make && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends make && \
     rm -rf /var/lib/apt/lists/*
 
 # Add channels to install specific R-packages


### PR DESCRIPTION
Da war ein Fehler bei den apt-Aufrufen. Aber bestimmt hast du den auch schon gefixt, wir haben ja gestern schon drüber geschrieben.

Hier ist jedenfalls der Fix.